### PR TITLE
feat(monorepo): configurar infraestrutura de packages

### DIFF
--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "apps/*"
+  - "packages/*"


### PR DESCRIPTION
## Summary
- Adiciona `packages/*` ao `pnpm-workspace.yaml` para suportar pacotes compartilhados
- Cria `packages/tsconfig.base.json` com configurações TypeScript base (ES2022, strict, ESM, declarations)

## Critérios de Aceite Atendidos
- [x] `pnpm install` funciona sem erros com a nova estrutura
- [x] Pacotes em `packages/*` são reconhecidos pelo Turborepo (via `pnpm-workspace.yaml`)
- [x] Configuração TypeScript base pronta para ser estendida pelos pacotes
- [x] `turbo.json` já suporta pacotes (usa `^build` e `^check-types`)
- [x] `biome.json` já cobre `packages/` (não está na lista de ignore)

## Notas
- `check-types` falha no `apps/api` por erro pré-existente (`schema.ts` vazio não exporta módulo) — será resolvido na issue #6
- Erros de lint são todos de `.claude/worktrees/` e arquivos pré-existentes com CRLF

## Test plan
- [x] `pnpm install` executa sem erros
- [x] `pnpm build` compila com sucesso (2/2 tasks)
- [x] Arquivos alterados passam no `biome check`

Closes #5