### PR TITLE
feat(logger): criar pacote @spec-driven/logger com Pino

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^10.0.0",
+    "@spec-driven/logger": "workspace:*",
     "drizzle-orm": "^0.36.0",
     "fastify": "^5.0.0",
     "postgres": "^3.4.0",
@@ -22,7 +23,6 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "drizzle-kit": "^0.28.0",
-    "pino-pretty": "^13.0.0",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0"

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,22 +1,13 @@
 import cors from "@fastify/cors"
+import { createFastifyLoggerConfig } from "@spec-driven/logger"
 import Fastify from "fastify"
 
 export function buildApp() {
   const app = Fastify({
-    logger: {
+    logger: createFastifyLoggerConfig({
+      name: "api",
       level: process.env.LOG_LEVEL ?? "info",
-      transport:
-        process.env.NODE_ENV !== "production"
-          ? {
-              target: "pino-pretty",
-              options: {
-                translateTime: "HH:MM:ss Z",
-                ignore: "pid,hostname",
-                colorize: true,
-              },
-            }
-          : undefined,
-    },
+    }),
   })
 
   app.register(cors, {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@spec-driven/logger",
+  "version": "0.0.0",
+  "private": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "pino": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "pino-pretty": "^13.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/packages/logger/src/config.ts
+++ b/packages/logger/src/config.ts
@@ -1,0 +1,18 @@
+import type { LoggerOptions as PinoLoggerOptions } from "pino"
+
+/** Whether the current environment is development. */
+export function isDev(env?: string): boolean {
+  return (env ?? process.env.NODE_ENV) !== "production"
+}
+
+/** Pino transport config for pretty-printing in development. */
+export function devTransport(): PinoLoggerOptions["transport"] {
+  return {
+    target: "pino-pretty",
+    options: {
+      translateTime: "HH:MM:ss Z",
+      ignore: "pid,hostname",
+      colorize: true,
+    },
+  }
+}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,2 @@
+export { createLogger, createFastifyLoggerConfig } from "./logger"
+export type { LoggerOptions, FastifyLoggerConfig } from "./types"

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,0 +1,46 @@
+import pino, { type Logger } from "pino"
+import { devTransport, isDev } from "./config"
+import type { FastifyLoggerConfig, LoggerOptions } from "./types"
+
+/**
+ * Creates a Pino logger instance.
+ *
+ * Uses `pino-pretty` in development and structured JSON in production.
+ *
+ * @example
+ * ```ts
+ * const logger = createLogger({ name: "my-service", level: "debug" })
+ * logger.info("Server started")
+ * logger.child({ module: "auth" }).warn("Token expired")
+ * ```
+ */
+export function createLogger(options: LoggerOptions): Logger {
+  const dev = isDev(options.env)
+
+  return pino({
+    name: options.name,
+    level: options.level ?? "info",
+    transport: dev ? devTransport() : undefined,
+  })
+}
+
+/**
+ * Creates a logger configuration object compatible with Fastify's `logger` option.
+ *
+ * @example
+ * ```ts
+ * import Fastify from "fastify"
+ * const app = Fastify({
+ *   logger: createFastifyLoggerConfig({ name: "api", level: "info" })
+ * })
+ * ```
+ */
+export function createFastifyLoggerConfig(options: LoggerOptions): FastifyLoggerConfig {
+  const dev = isDev(options.env)
+
+  return {
+    name: options.name,
+    level: options.level ?? "info",
+    transport: dev ? devTransport() : undefined,
+  }
+}

--- a/packages/logger/src/types.ts
+++ b/packages/logger/src/types.ts
@@ -1,0 +1,14 @@
+import type { LoggerOptions as PinoLoggerOptions } from "pino"
+
+/** Options for creating a logger instance. */
+export interface LoggerOptions {
+  /** Service or module name, included in every log entry. */
+  name: string
+  /** Minimum log level. Defaults to `"info"`. */
+  level?: string
+  /** Force a specific environment instead of auto-detecting from `NODE_ENV`. */
+  env?: "development" | "production"
+}
+
+/** The logger config object compatible with Fastify's `logger` option. */
+export type FastifyLoggerConfig = PinoLoggerOptions

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/logger/tsup.config.ts
+++ b/packages/logger/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  outDir: "dist",
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@fastify/cors':
         specifier: ^10.0.0
         version: 10.1.0
+      '@spec-driven/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
       drizzle-orm:
         specifier: ^0.36.0
         version: 0.36.4(postgres@3.4.8)
@@ -39,9 +42,6 @@ importers:
       drizzle-kit:
         specifier: ^0.28.0
         version: 0.28.1
-      pino-pretty:
-        specifier: ^13.0.0
-        version: 13.1.3
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
@@ -88,6 +88,47 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.1.1(@types/react@19.1.0)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+
+  packages/db:
+    dependencies:
+      drizzle-orm:
+        specifier: ^0.36.0
+        version: 0.36.4(postgres@3.4.8)
+      postgres:
+        specifier: ^3.4.0
+        version: 3.4.8
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.15.3
+      drizzle-kit:
+        specifier: ^0.28.0
+        version: 0.28.1
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+
+  packages/logger:
+    dependencies:
+      pino:
+        specifier: ^9.0.0
+        version: 9.14.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.15.3
+      pino-pretty:
+        specifier: ^13.0.0
+        version: 13.1.3
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -2358,6 +2399,12 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+    dependencies:
+      split2: 4.2.0
+    dev: false
+
   /pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
     dependencies:
@@ -2401,6 +2448,23 @@ packages:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+    dev: false
+
+  /pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
     dev: false
 
   /pirates@4.0.7:
@@ -2718,6 +2782,12 @@ packages:
     dependencies:
       any-promise: 1.3.0
     dev: true
+
+  /thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+    dependencies:
+      real-require: 0.2.0
+    dev: false
 
   /thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}


### PR DESCRIPTION
## Summary
- Cria o pacote `packages/logger` com sistema de logging estruturado usando Pino
- Exporta `createLogger` para uso standalone e `createFastifyLoggerConfig` para integração com Fastify
- Detecção automática de ambiente: `pino-pretty` em desenvolvimento, JSON estruturado em produção
- Atualiza `apps/api` para usar o novo pacote, removendo configuração inline de logging

## Critérios de Aceite Atendidos
- [x] `@spec-driven/logger` exporta `createLogger` e `createFastifyLoggerConfig`
- [x] Logger usa pino-pretty em dev e JSON puro em produção
- [x] Child loggers funcionam com contexto adicional
- [x] `apps/api` usa o pacote para configurar o logger do Fastify
- [x] Build (`pnpm build`) passa sem erros
- [x] Tipagem completa em todos os exports

## Test plan
- [ ] Rodar `pnpm build` e verificar que todos os pacotes compilam sem erros
- [ ] Rodar `pnpm check-types` e verificar tipagem
- [ ] Testar `pnpm dev` na API e verificar logs formatados com pino-pretty
- [ ] Verificar que `createLogger({ name: "test" })` funciona standalone
- [ ] Verificar que child loggers preservam contexto (`logger.child({ module: "auth" })`)

Closes #7