### PR TITLE
feat(http): criar pacote @spec-driven/http com Fastify e middlewares

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,10 +10,9 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "@fastify/cors": "^10.0.0",
     "@spec-driven/db": "workspace:*",
+    "@spec-driven/http": "workspace:*",
     "@spec-driven/logger": "workspace:*",
-    "fastify": "^5.0.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,22 +1,14 @@
-import cors from "@fastify/cors"
+import { createServer } from "@spec-driven/http"
 import { createFastifyLoggerConfig } from "@spec-driven/logger"
-import Fastify from "fastify"
 
 export function buildApp() {
-  const app = Fastify({
+  const server = createServer({
     logger: createFastifyLoggerConfig({
       name: "api",
       level: process.env.LOG_LEVEL ?? "info",
     }),
+    cors: { origin: true },
   })
 
-  app.register(cors, {
-    origin: true,
-  })
-
-  app.get("/health", async () => {
-    return { status: "ok", timestamp: new Date().toISOString() }
-  })
-
-  return app
+  return server
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,7 +6,7 @@ const HOST = process.env.HOST ?? "0.0.0.0"
 const app = buildApp()
 
 try {
-  await app.listen({ port: PORT, host: HOST })
+  await app.start({ port: PORT, host: HOST })
 } catch (err) {
   app.log.error(err)
   process.exit(1)

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@spec-driven/http",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@fastify/cors": "^10.0.0",
+    "@spec-driven/logger": "workspace:*",
+    "fastify": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "pino-pretty": "^13.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.5.0",
+    "zod": "^3.23.0"
+  }
+}

--- a/packages/http/src/errors.ts
+++ b/packages/http/src/errors.ts
@@ -1,0 +1,41 @@
+export class AppError extends Error {
+  readonly statusCode: number
+  readonly code: string
+
+  constructor(message: string, statusCode = 500, code = "INTERNAL_ERROR") {
+    super(message)
+    this.name = this.constructor.name
+    this.statusCode = statusCode
+    this.code = code
+  }
+}
+
+export class BadRequestError extends AppError {
+  constructor(message = "Bad Request") {
+    super(message, 400, "BAD_REQUEST")
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message = "Unauthorized") {
+    super(message, 401, "UNAUTHORIZED")
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = "Forbidden") {
+    super(message, 403, "FORBIDDEN")
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = "Not Found") {
+    super(message, 404, "NOT_FOUND")
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message = "Conflict") {
+    super(message, 409, "CONFLICT")
+  }
+}

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,0 +1,27 @@
+export { createServer } from "./server.js"
+
+export {
+  AppError,
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  UnauthorizedError,
+} from "./errors.js"
+
+export {
+  registerCors,
+  registerErrorHandler,
+  registerHealthCheck,
+  registerRequestId,
+} from "./middlewares/index.js"
+
+export type {
+  CorsOptions,
+  ErrorResponse,
+  HealthCheckOptions,
+  ReadinessChecker,
+  ServerInstance,
+  ServerOptions,
+  StartOptions,
+} from "./types.js"

--- a/packages/http/src/middlewares/cors.ts
+++ b/packages/http/src/middlewares/cors.ts
@@ -1,0 +1,12 @@
+import fastifyCors from "@fastify/cors"
+import type { FastifyInstance } from "fastify"
+import type { CorsOptions } from "../types.js"
+
+export async function registerCors(app: FastifyInstance, options: CorsOptions = {}) {
+  await app.register(fastifyCors, {
+    origin: options.origin ?? true,
+    methods: options.methods,
+    allowedHeaders: options.allowedHeaders,
+    credentials: options.credentials,
+  })
+}

--- a/packages/http/src/middlewares/error-handler.ts
+++ b/packages/http/src/middlewares/error-handler.ts
@@ -1,0 +1,64 @@
+import type { FastifyError, FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
+import { AppError } from "../errors.js"
+import type { ErrorResponse } from "../types.js"
+
+interface ZodIssue {
+  message: string
+  path: (string | number)[]
+}
+
+function isZodError(error: unknown): error is Error & { issues: ZodIssue[] } {
+  return (
+    error instanceof Error &&
+    error.name === "ZodError" &&
+    "issues" in error &&
+    Array.isArray((error as Record<string, unknown>).issues)
+  )
+}
+
+export async function registerErrorHandler(app: FastifyInstance) {
+  app.setErrorHandler((error: FastifyError, request: FastifyRequest, reply: FastifyReply) => {
+    if (isZodError(error)) {
+      const message = error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ")
+
+      const body: ErrorResponse = {
+        error: {
+          code: "VALIDATION_ERROR",
+          message,
+          statusCode: 400,
+        },
+      }
+
+      return reply.status(400).send(body)
+    }
+
+    if (error instanceof AppError) {
+      if (error.statusCode >= 500) {
+        request.log.error({ err: error }, error.message)
+      }
+
+      const body: ErrorResponse = {
+        error: {
+          code: error.code,
+          message: error.message,
+          statusCode: error.statusCode,
+        },
+      }
+
+      return reply.status(error.statusCode).send(body)
+    }
+
+    request.log.error({ err: error }, error.message)
+
+    const statusCode = (error as { statusCode?: number }).statusCode ?? 500
+    const body: ErrorResponse = {
+      error: {
+        code: "INTERNAL_ERROR",
+        message: statusCode >= 500 ? "Internal Server Error" : error.message,
+        statusCode,
+      },
+    }
+
+    return reply.status(statusCode).send(body)
+  })
+}

--- a/packages/http/src/middlewares/health-check.ts
+++ b/packages/http/src/middlewares/health-check.ts
@@ -1,0 +1,28 @@
+import type { FastifyInstance } from "fastify"
+import type { HealthCheckOptions } from "../types.js"
+
+export async function registerHealthCheck(app: FastifyInstance, options: HealthCheckOptions = {}) {
+  app.get("/health", async () => {
+    return { status: "ok", timestamp: new Date().toISOString() }
+  })
+
+  app.get("/ready", async (_request, reply) => {
+    const checkers = options.readinessCheckers ?? []
+
+    if (checkers.length === 0) {
+      return { status: "ok", timestamp: new Date().toISOString() }
+    }
+
+    try {
+      await Promise.all(checkers.map((check) => check()))
+      return { status: "ok", timestamp: new Date().toISOString() }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Readiness check failed"
+      return reply.status(503).send({
+        status: "unavailable",
+        message,
+        timestamp: new Date().toISOString(),
+      })
+    }
+  })
+}

--- a/packages/http/src/middlewares/index.ts
+++ b/packages/http/src/middlewares/index.ts
@@ -1,0 +1,4 @@
+export { registerCors } from "./cors.js"
+export { registerRequestId } from "./request-id.js"
+export { registerErrorHandler } from "./error-handler.js"
+export { registerHealthCheck } from "./health-check.js"

--- a/packages/http/src/middlewares/request-id.ts
+++ b/packages/http/src/middlewares/request-id.ts
@@ -1,0 +1,14 @@
+import type { FastifyInstance } from "fastify"
+
+export async function registerRequestId(app: FastifyInstance) {
+  app.addHook("onRequest", async (request) => {
+    const incomingId = request.headers["x-request-id"]
+    if (typeof incomingId === "string" && incomingId.length > 0) {
+      request.id = incomingId
+    }
+  })
+
+  app.addHook("onSend", async (_request, reply) => {
+    reply.header("x-request-id", reply.request.id)
+  })
+}

--- a/packages/http/src/plugins/index.ts
+++ b/packages/http/src/plugins/index.ts
@@ -1,0 +1,6 @@
+export {
+  registerCors,
+  registerRequestId,
+  registerErrorHandler,
+  registerHealthCheck,
+} from "../middlewares/index.js"

--- a/packages/http/src/server.ts
+++ b/packages/http/src/server.ts
@@ -1,0 +1,33 @@
+import Fastify from "fastify"
+import { registerCors } from "./middlewares/cors.js"
+import { registerErrorHandler } from "./middlewares/error-handler.js"
+import { registerHealthCheck } from "./middlewares/health-check.js"
+import { registerRequestId } from "./middlewares/request-id.js"
+import type { ServerInstance, ServerOptions, StartOptions } from "./types.js"
+
+export function createServer(options: ServerOptions = {}): ServerInstance {
+  const app = Fastify({
+    logger: options.logger ?? true,
+  })
+
+  app.register(async (instance) => {
+    await registerCors(instance, options.cors)
+    await registerRequestId(instance)
+    await registerErrorHandler(instance)
+    await registerHealthCheck(instance, options.healthCheck)
+  })
+
+  app.decorate("start", async ({ port, host = "0.0.0.0" }: StartOptions) => {
+    await app.listen({ port, host })
+
+    const shutdown = async () => {
+      app.log.info("Shutting down gracefully...")
+      await app.close()
+    }
+
+    process.on("SIGTERM", shutdown)
+    process.on("SIGINT", shutdown)
+  })
+
+  return app as unknown as ServerInstance
+}

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -1,0 +1,34 @@
+import type { FastifyInstance, FastifyServerOptions } from "fastify"
+
+export interface CorsOptions {
+  origin?: boolean | string | string[] | RegExp | RegExp[]
+  methods?: string[]
+  allowedHeaders?: string[]
+  credentials?: boolean
+}
+
+export type ReadinessChecker = () => Promise<void>
+
+export interface HealthCheckOptions {
+  readinessCheckers?: ReadinessChecker[]
+}
+
+export interface ServerOptions {
+  logger?: FastifyServerOptions["logger"]
+  cors?: CorsOptions
+  healthCheck?: HealthCheckOptions
+}
+
+export type StartOptions = { port: number; host?: string }
+
+export type ServerInstance = FastifyInstance & {
+  start: (options: StartOptions) => Promise<void>
+}
+
+export interface ErrorResponse {
+  error: {
+    code: string
+    message: string
+    statusCode: number
+  }
+}

--- a/packages/http/tsconfig.json
+++ b/packages/http/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/http/tsup.config.ts
+++ b/packages/http/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  outDir: "dist",
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,18 +17,15 @@ importers:
 
   apps/api:
     dependencies:
-      '@fastify/cors':
-        specifier: ^10.0.0
-        version: 10.1.0
       '@spec-driven/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@spec-driven/http':
+        specifier: workspace:*
+        version: link:../../packages/http
       '@spec-driven/logger':
         specifier: workspace:*
         version: link:../../packages/logger
-      fastify:
-        specifier: ^5.0.0
-        version: 5.7.4
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -110,6 +107,34 @@ importers:
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
+
+  packages/http:
+    dependencies:
+      '@fastify/cors':
+        specifier: ^10.0.0
+        version: 10.1.0
+      '@spec-driven/logger':
+        specifier: workspace:*
+        version: link:../logger
+      fastify:
+        specifier: ^5.0.0
+        version: 5.7.4
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.15.3
+      pino-pretty:
+        specifier: ^13.0.0
+        version: 13.1.3
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
 
   packages/logger:
     dependencies:
@@ -2958,4 +2983,3 @@ packages:
 
   /zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-    dev: false


### PR DESCRIPTION
## Summary
- Cria o pacote `@spec-driven/http` (`packages/http`) com factory `createServer()`, middlewares e classes de erro HTTP
- Implementa CORS, request-id, error handler global e health check como middlewares pré-registrados
- Cria classes de erro HTTP: `AppError`, `NotFoundError`, `BadRequestError`, `UnauthorizedError`, `ForbiddenError`, `ConflictError`
- Refatora `apps/api` para usar `@spec-driven/http` como base do servidor

## Critérios de Aceite Atendidos
- [x] `@spec-driven/http` exporta `createServer`, error classes e tipos
- [x] Server vem com CORS, request-id, error-handler e health-check pré-registrados
- [x] Error handler retorna formato padronizado `{ error: { code, message, statusCode } }` e loga erros 5xx
- [x] Tratamento de erros Zod (validation)
- [x] Health check com liveness (`/health`) e readiness (`/ready`) endpoints
- [x] `apps/api` usa o pacote como base do servidor
- [x] Build (`pnpm build`) passa sem erros
- [x] Tipagem completa em todos os exports

## Test plan
- [ ] Rodar `pnpm install && pnpm build` — deve compilar sem erros
- [ ] Rodar `pnpm lint` — sem issues
- [ ] Rodar `pnpm check-types` — sem erros de tipo
- [ ] Rodar `pnpm dev` e testar `GET /health` na API (porta 3001)
- [ ] Rodar `pnpm dev` e testar `GET /ready` na API (porta 3001)
- [ ] Verificar que responses de erro seguem o formato padronizado

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)