### PR TITLE
feat(api): adiciona endpoint POST /auth/logout com revogação de tokens

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -26,6 +26,7 @@ apps/api/
 │       └── use-cases/
 │           ├── register.ts           ← RegisterUseCase
 │           ├── authenticate.ts       ← AuthenticateUseCase
+│           ├── logout.ts             ← LogoutUseCase
 │           ├── refresh-token.ts      ← RefreshTokenUseCase
 │           └── get-profile.ts        ← GetProfileUseCase
 │
@@ -37,7 +38,7 @@ apps/api/
 │       ├── plugins/
 │       │   └── swagger.ts            ← @fastify/swagger + Scalar (OpenAPI docs)
 │       ├── routes/
-│       │   ├── auth-routes.ts        ← POST /auth/register, /auth/login, /auth/refresh
+│       │   ├── auth-routes.ts        ← POST /auth/register, /auth/login, /auth/refresh, /auth/logout
 │       │   └── user-routes.ts        ← GET /me (protegida por Bearer)
 │       └── schemas/
 │           ├── auth-schemas.ts       ← Zod schemas de request + response
@@ -103,6 +104,7 @@ Validação via Zod em `config/env.ts` — falha fast no startup se variáveis o
 | POST | `/auth/register` | Não | `{ name, email, password }` | `201 { user }` |
 | POST | `/auth/login` | Não | `{ email, password }` | `200 { accessToken, refreshToken, user }` |
 | POST | `/auth/refresh` | Não | `{ refreshToken }` | `200 { accessToken, refreshToken }` |
+| POST | `/auth/logout` | Bearer | — | `204 No Content` |
 | GET | `/me` | Bearer | — | `200 { user }` |
 | GET | `/docs` | Não | — | Scalar UI (documentação interativa) |
 | GET | `/openapi.json` | Não | — | OpenAPI 3.1 spec JSON |

--- a/apps/api/application/user/use-cases/logout.ts
+++ b/apps/api/application/user/use-cases/logout.ts
@@ -1,0 +1,9 @@
+import type { UserRepository } from "../../../domain/user/repository.js"
+
+export class LogoutUseCase {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async execute(userId: string): Promise<void> {
+    await this.userRepository.revokeAllUserRefreshTokens(userId)
+  }
+}

--- a/apps/api/index.ts
+++ b/apps/api/index.ts
@@ -6,6 +6,7 @@ import { serializerCompiler, validatorCompiler } from "fastify-type-provider-zod
 import { AuthenticateUseCase } from "./application/user/use-cases/authenticate.js"
 import { GetProfileUseCase } from "./application/user/use-cases/get-profile.js"
 import { RefreshTokenUseCase } from "./application/user/use-cases/refresh-token.js"
+import { LogoutUseCase } from "./application/user/use-cases/logout.js"
 import { RegisterUseCase } from "./application/user/use-cases/register.js"
 import { env } from "./config/env.js"
 import { DrizzleUserRepository } from "./infrastructure/database/repositories/drizzle-user-repository.js"
@@ -25,6 +26,7 @@ const userRepository = new DrizzleUserRepository(db)
 const registerUseCase = new RegisterUseCase(userRepository, hasher)
 const authenticateUseCase = new AuthenticateUseCase(userRepository, hasher, tokenProvider)
 const refreshTokenUseCase = new RefreshTokenUseCase(userRepository, tokenProvider)
+const logoutUseCase = new LogoutUseCase(userRepository)
 const getProfileUseCase = new GetProfileUseCase(userRepository)
 
 // Server
@@ -43,12 +45,18 @@ server.setSerializerCompiler(serializerCompiler)
 // Swagger + Scalar docs
 await registerSwagger(server)
 
+// Auth middleware
+const authMiddleware = createAuthMiddleware({ secret: env.JWT_SECRET })
+
 // Routes
-registerAuthRoutes(server, { registerUseCase, authenticateUseCase, refreshTokenUseCase })
-registerUserRoutes(server, {
-  getProfileUseCase,
-  authMiddleware: createAuthMiddleware({ secret: env.JWT_SECRET }),
+registerAuthRoutes(server, {
+  registerUseCase,
+  authenticateUseCase,
+  refreshTokenUseCase,
+  logoutUseCase,
+  authMiddleware,
 })
+registerUserRoutes(server, { getProfileUseCase, authMiddleware })
 
 try {
   await server.start({ port: env.PORT, host: env.HOST })

--- a/apps/api/infrastructure/http/routes/auth-routes.ts
+++ b/apps/api/infrastructure/http/routes/auth-routes.ts
@@ -1,6 +1,8 @@
 import type { ServerInstance } from "@spec-driven/http"
+import type { FastifyReply, FastifyRequest } from "fastify"
 import type { ZodTypeProvider } from "fastify-type-provider-zod"
 import type { AuthenticateUseCase } from "../../../application/user/use-cases/authenticate.js"
+import type { LogoutUseCase } from "../../../application/user/use-cases/logout.js"
 import type { RefreshTokenUseCase } from "../../../application/user/use-cases/refresh-token.js"
 import type { RegisterUseCase } from "../../../application/user/use-cases/register.js"
 import {
@@ -17,6 +19,8 @@ interface AuthRouteDeps {
   registerUseCase: RegisterUseCase
   authenticateUseCase: AuthenticateUseCase
   refreshTokenUseCase: RefreshTokenUseCase
+  logoutUseCase: LogoutUseCase
+  authMiddleware: (request: FastifyRequest, reply: FastifyReply) => Promise<void>
 }
 
 export function registerAuthRoutes(app: ServerInstance, deps: AuthRouteDeps) {
@@ -83,6 +87,28 @@ export function registerAuthRoutes(app: ServerInstance, deps: AuthRouteDeps) {
     async (request, reply) => {
       const result = await deps.refreshTokenUseCase.execute(request.body)
       return reply.status(200).send(result)
+    }
+  )
+
+  typedApp.post(
+    "/auth/logout",
+    {
+      preHandler: [deps.authMiddleware],
+      schema: {
+        summary: "Logout user",
+        description:
+          "Revokes all refresh tokens for the authenticated user, effectively logging them out.",
+        tags: ["auth"],
+        security: [{ bearerAuth: [] }],
+        response: {
+          204: { type: "null", description: "No Content" },
+          401: errorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      await deps.logoutUseCase.execute(request.user.sub)
+      return reply.status(204).send()
     }
   )
 }


### PR DESCRIPTION
## Summary
- Cria `LogoutUseCase` que revoga todos os refresh tokens do usuário
- Adiciona rota `POST /auth/logout` protegida por Bearer token (204 No Content)
- Documenta endpoint no OpenAPI (tag `auth`, security `bearerAuth`)
- Compartilha instância de `authMiddleware` entre auth-routes e user-routes

## Critérios de Aceite Atendidos
- [x] `POST /auth/logout` com Bearer token válido retorna `204`
- [x] Todos os refresh tokens do usuário são revogados após logout
- [x] Tentar usar um refresh token antigo após logout retorna `401`
- [x] Endpoint requer autenticação (retorna 401 sem token)

## Test plan
- [ ] `POST /auth/logout` sem token → 401
- [ ] `POST /auth/logout` com token expirado → 401
- [ ] Login → Logout → tentar refresh com token antigo → 401
- [ ] Login → Logout → verificar que response é 204 sem body

Closes #22